### PR TITLE
fix: wiki 图片嵌入上传后转 Markdown，避免 ![[远程URL]] 无法显示

### DIFF
--- a/src/upload/imageHandler.ts
+++ b/src/upload/imageHandler.ts
@@ -682,6 +682,16 @@ export class ImageHandler {
 			if (wikiMatch) {
 				const segments = wikiMatch[1].split('|');
 				if (segments.length > 0) {
+					// 上传后图片已变为远程 URL，而 Obsidian 的 ![[ ]] 嵌入只解析库内文件，
+					// 无法渲染 http(s) 或绝对路径链接，会显示为损坏的内部嵌入。
+					// 此时转成标准 Markdown，并把原来的尺寸段（如 |200）作为 Markdown alt
+					// 携带过去以保留宽高（Obsidian 中纯数字 alt 即为图片宽度）。
+					const isRemoteUrl = /^https?:\/\//i.test(uploadedUrl) || uploadedUrl.startsWith('/');
+					if (isRemoteUrl) {
+						const sizeOrAlt = segments.slice(1).join('|').trim();
+						const altText = sizeOrAlt || this.getFallbackImageName(reference.path);
+						return this.buildMarkdownImage(altText, uploadedUrl, this.getFallbackImageName(reference.path));
+					}
 					segments[0] = uploadedUrl;
 					return `![[${segments.join('|')}]]`;
 				}


### PR DESCRIPTION
## 问题 / Problem
对使用 **wiki 嵌入语法** 的笔记执行「批量替换当前笔记图片链接」后，`![[name.jpg|200]]` 被替换为 `![[http://host/file/xxx.jpg|200]]`。由于 Obsidian 的 `![[ ]]` 嵌入**只解析库内文件、不解析 http(s) URL**，图片无法显示。

详见 #14。

## 修改 / Change
`buildReplacementForReference()` 的 **wiki 分支**：当替换进去的 `uploadedUrl` 为远程链接（`http(s)://` 或绝对路径）时，改为输出标准 Markdown `![尺寸](url)`，并把原来的 `|尺寸` 段作为 markdown alt 保留宽高（Obsidian 中纯数字 alt 即图片宽度）；**本地（库内）路径仍走原 `![[ ]]` 逻辑，行为不变**。

仅改动 `src/upload/imageHandler.ts`（+10 行），markdown 分支与其它行为均不受影响。

```ts
const isRemoteUrl = /^https?:\/\//i.test(uploadedUrl) || uploadedUrl.startsWith('/');
if (isRemoteUrl) {
    const sizeOrAlt = segments.slice(1).join('|').trim();
    const altText = sizeOrAlt || this.getFallbackImageName(reference.path);
    return this.buildMarkdownImage(altText, uploadedUrl, this.getFallbackImageName(reference.path));
}
```

## Before / After
| | 结果 |
|---|---|
| 输入 | `![[some.jpg\|200]]` |
| 之前 | `![[http://.../file/xxx.jpg\|200]]` ❌ 无法显示 |
| 之后 | `![200](http://.../file/xxx.jpg)` ✅ 正常，宽度 200 保留 |

## 测试 / Testing
基于 v1.0.8 本地编译此改动（`tsc --noEmit` 类型检查通过 + esbuild production），替换到运行中的 Obsidian 实测：wiki 图片上传后输出正确 markdown 并正常显示；本地路径与 markdown 语法用例回归正常。

Fixes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)
