### PR TITLE
fix: 抓取远程图片时带上 Referer + UA，修复防盗链站点 403 导致网络图片上传失败

### DIFF
--- a/src/upload/imageHandler.ts
+++ b/src/upload/imageHandler.ts
@@ -641,7 +641,18 @@ export class ImageHandler {
 	}
 
 	private async fetchRemoteImageFile(url: string, altText: string): Promise<File> {
-		const response = await requestUrl({ url });
+		// 部分图床/CDN 启用了 Referer 防盗链，直接请求会返回 403。
+		// 带上「图片自身来源站」的 Referer + 浏览器 UA，可绕过绝大多数同域防盗链。
+		const requestHeaders: Record<string, string> = {
+			'User-Agent':
+				'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36'
+		};
+		try {
+			requestHeaders['Referer'] = new URL(url).origin + '/';
+		} catch (_) {
+			// URL 解析失败则不带 Referer
+		}
+		const response = await requestUrl({ url, headers: requestHeaders });
 		if (response.status < 200 || response.status >= 300) {
 			throw new Error(`下载失败：${response.status}`);
 		}


### PR DESCRIPTION
## 问题

`ImageHandler.fetchRemoteImageFile()` 目前是裸调 `requestUrl({ url })`，不带任何请求头。

不少站点/CDN 开启了 Referer 防盗链，**空 Referer 会直接返回 403**，导致「启用网络图片上传 / 批量替换当前笔记图片链接」对这类外链图片整体失效——图片抓不下来，链接只能保持原样。

实测例子：少数派的 `cdnfile.sspai.com`，空 Referer 请求稳定 403。

## 改动

下载远程图片时补两个请求头：

- `User-Agent`：常见浏览器 UA
- `Referer`：**图片自身的 origin**（`new URL(url).origin + '/'`）

```ts
const requestHeaders: Record<string, string> = { 'User-Agent': '...' };
try {
    requestHeaders['Referer'] = new URL(url).origin + '/';
} catch (_) {
    // URL 解析失败则不带 Referer
}
const response = await requestUrl({ url, headers: requestHeaders });
```

URL 解析失败时静默降级为不带 Referer，行为与改动前一致。

## 效果与边界

- ✅ 可绕过最常见的「同域 Referer 校验」型防盗链（实测 sspai 通过）
- ❌ 签名 URL、token / 时效性链接、要求特定跨域 Referer 或 Cookie 的图片仍然拿不到——这类本来也拿不到，行为无退化

## 影响面

只改 `src/upload/imageHandler.ts` 一个函数，+12 行，无新增设置项，不改变任何既有行为。已在 1.0.9 上通过 `tsc --noEmit`。
