### PR TITLE
feat: 新增「外部写入自动上传」（AI CLI 写文件 / 网页剪藏场景），默认关闭

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -3,6 +3,7 @@ import { CFImageBedSettings, DEFAULT_SETTINGS } from './src/types';
 import { UploadService } from './src/upload/uploadService';
 import { ImageHandler } from './src/upload/imageHandler';
 import { EventHandlers } from './src/events/eventHandlers';
+import { AutoUploadWatcher } from './src/events/autoUploadWatcher';
 import { CFImageBedSettingTab } from './src/settings/settingsTab';
 import { I18n, resolveLanguage } from './src/utils/i18n';
 import { parseDomainList } from './src/utils/domainUtils';
@@ -12,6 +13,7 @@ export default class CFImageBedPlugin extends Plugin {
 	private uploadService: UploadService;
 	private imageHandler: ImageHandler;
 	private eventHandlers: EventHandlers;
+	private autoUploadWatcher: AutoUploadWatcher;
 	private i18n: I18n;
 
 	async onload() {
@@ -29,6 +31,11 @@ export default class CFImageBedPlugin extends Plugin {
 		this.eventHandlers.registerDragAndDropEvents(this);
 		this.eventHandlers.registerPasteEvents(this);
 		this.eventHandlers.registerEditorMenuEvents(this);
+
+		// 自动上传监听器（AI 经 CLI 写文件 / Web Clip 等外部写入时自动转存图床）。
+		// 在 onLayoutReady 之后再注册，避免 Obsidian 启动时对全库触发 create 事件。
+		this.autoUploadWatcher = new AutoUploadWatcher(this, this.imageHandler, () => this.settings, this.i18n);
+		this.app.workspace.onLayoutReady(() => this.autoUploadWatcher.register());
 
 		// 移动端专用命令：支持相机拍照和相册选择
 		this.addCommand({

--- a/src/events/autoUploadWatcher.ts
+++ b/src/events/autoUploadWatcher.ts
@@ -1,0 +1,107 @@
+import { Notice, Plugin, TAbstractFile, TFile, debounce } from 'obsidian';
+import { ImageHandler } from '../upload/imageHandler';
+import { CFImageBedSettings } from '../types';
+import { I18n } from '../utils/i18n';
+
+type DebouncedFn = ReturnType<typeof debounce>;
+
+/**
+ * 自动上传监听器：监听 vault 的 create / modify 事件，对「从外部写入磁盘」的
+ * Markdown 笔记（如 AI 通过 CLI 写文件、Web Clip 存网页）自动检查其中的本地/远程
+ * 图片，转存到图床并改写链接。
+ *
+ * 安全设计：
+ *  - 仅在 onLayoutReady 之后注册（见 main.ts），避免启动时全库 create 事件风暴。
+ *  - 每个文件独立防抖，等写入落定再处理，绝不动到正在写的内容。
+ *  - processing 集合 + 幂等性（转存后图片已在图床域、被排除域过滤，二次扫描为 0）
+ *    双重断环，杜绝「自己改写又触发 modify」的死循环。
+ *  - vault.process 原子写回，且仅当磁盘内容仍等于所处理快照时才覆盖。
+ */
+export class AutoUploadWatcher {
+	private processing = new Set<string>();
+	private debouncers = new Map<string, DebouncedFn>();
+
+	constructor(
+		private plugin: Plugin,
+		private imageHandler: ImageHandler,
+		private getSettings: () => CFImageBedSettings,
+		private i18n: I18n
+	) {}
+
+	/** 在 workspace.onLayoutReady 回调里调用，避免启动事件风暴。 */
+	register(): void {
+		const vault = this.plugin.app.vault;
+		this.plugin.registerEvent(vault.on('create', (file) => this.onVaultChange(file)));
+		this.plugin.registerEvent(vault.on('modify', (file) => this.onVaultChange(file)));
+	}
+
+	private onVaultChange(file: TAbstractFile): void {
+		const settings = this.getSettings();
+		if (!settings?.enableAutoUpload) {
+			return;
+		}
+		if (!(file instanceof TFile) || file.extension !== 'md') {
+			return;
+		}
+		if (!this.isWatchedPath(file.path, settings)) {
+			return;
+		}
+		if (this.processing.has(file.path)) {
+			return;
+		}
+
+		const delay = Math.max(500, settings.autoUploadDebounceMs ?? 2000);
+		let debounced = this.debouncers.get(file.path);
+		if (!debounced) {
+			debounced = debounce(() => {
+				void this.processFile(file.path);
+			}, delay, true);
+			this.debouncers.set(file.path, debounced);
+		}
+		debounced();
+	}
+
+	private isWatchedPath(path: string, settings: CFImageBedSettings): boolean {
+		const folders = (settings.autoUploadFolders || '')
+			.split(',')
+			.map((f) => f.trim().replace(/^\/+|\/+$/g, ''))
+			.filter((f) => f.length > 0);
+		if (folders.length === 0) {
+			return true; // 未配置 = 全库
+		}
+		return folders.some((folder) => path === folder || path.startsWith(folder + '/'));
+	}
+
+	private async processFile(path: string): Promise<void> {
+		if (this.processing.has(path)) {
+			return;
+		}
+		const file = this.plugin.app.vault.getAbstractFileByPath(path);
+		if (!(file instanceof TFile)) {
+			return;
+		}
+
+		this.processing.add(path);
+		try {
+			const original = await this.plugin.app.vault.read(file);
+			const result = await this.imageHandler.uploadImagesInText(original, file, file.path);
+			if (result.success > 0) {
+				// 原子写回：仅当磁盘内容仍等于刚处理的快照时才覆盖，避免覆盖期间的新改动。
+				await this.plugin.app.vault.process(file, (current) =>
+					current === original ? result.content : current
+				);
+				const settings = this.getSettings();
+				if (settings?.showUploadProgress) {
+					new Notice(this.i18n.t('notices.autoUploadSummary', {
+						count: String(result.success),
+						file: file.name
+					}));
+				}
+			}
+		} catch (error) {
+			console.error('CF ImageBed auto-upload failed:', error);
+		} finally {
+			this.processing.delete(path);
+		}
+	}
+}

--- a/src/settings/settingsTab.ts
+++ b/src/settings/settingsTab.ts
@@ -469,6 +469,39 @@ export class CFImageBedSettingTab extends PluginSettingTab {
 					await this.plugin.saveSettings();
 				}));
 
+		new Setting(container)
+			.setName(this.i18n.t('settings.advanced.enableAutoUpload.name'))
+			.setDesc(this.i18n.t('settings.advanced.enableAutoUpload.desc'))
+			.addToggle((toggle: ToggleComponent) => toggle
+				.setValue(this.plugin.settings.enableAutoUpload)
+				.onChange(async (value: boolean) => {
+					this.plugin.settings.enableAutoUpload = value;
+					await this.plugin.saveSettings();
+				}));
+
+		new Setting(container)
+			.setName(this.i18n.t('settings.advanced.autoUploadFolders.name'))
+			.setDesc(this.i18n.t('settings.advanced.autoUploadFolders.desc'))
+			.addText((text) => text
+				.setPlaceholder(this.i18n.t('settings.advanced.autoUploadFolders.placeholder'))
+				.setValue(this.plugin.settings.autoUploadFolders)
+				.onChange(async (value: string) => {
+					this.plugin.settings.autoUploadFolders = value;
+					await this.plugin.saveSettings();
+				}));
+
+		new Setting(container)
+			.setName(this.i18n.t('settings.advanced.autoUploadDebounceMs.name'))
+			.setDesc(this.i18n.t('settings.advanced.autoUploadDebounceMs.desc'))
+			.addText((text) => text
+				.setPlaceholder(this.i18n.t('settings.advanced.autoUploadDebounceMs.placeholder'))
+				.setValue(String(this.plugin.settings.autoUploadDebounceMs))
+				.onChange(async (value: string) => {
+					const parsed = parseInt(value, 10);
+					this.plugin.settings.autoUploadDebounceMs = Number.isFinite(parsed) && parsed > 0 ? parsed : 2000;
+					await this.plugin.saveSettings();
+				}));
+
 		const autoExcludedDomain = extractHostname(this.plugin.settings.apiUrl);
 		const excludedDescSuffix = autoExcludedDomain
 			? `\n${this.i18n.getLanguage() === 'zh' ? '当前自动排除：' : 'Auto excluded:'} ${autoExcludedDomain}`

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -34,6 +34,11 @@ export interface CFImageBedSettings {
 	targetSize: number; // MB - 期望大小
 	enableNetworkImageUpload: boolean;
 	excludedImageDomains: string[];
+
+	// 自动上传配置（AI 通过 CLI 写入 / Web Clip 等外部写入时自动转存图床）
+	enableAutoUpload: boolean;
+	autoUploadDebounceMs: number; // 文件改动后等待落定的防抖毫秒
+	autoUploadFolders: string; // 逗号分隔的监听文件夹；留空 = 全库
 	
 	// 用户体验配置
 	showUploadProgress: boolean;
@@ -82,6 +87,11 @@ export const DEFAULT_SETTINGS: CFImageBedSettings = {
 	targetSize: 1, // 1MB
 	enableNetworkImageUpload: false,
 	excludedImageDomains: [],
+
+	// 自动上传配置
+	enableAutoUpload: false,
+	autoUploadDebounceMs: 2000,
+	autoUploadFolders: '',
 	
 	// 用户体验配置
 	showUploadProgress: true,

--- a/src/upload/imageHandler.ts
+++ b/src/upload/imageHandler.ts
@@ -180,6 +180,61 @@ export class ImageHandler {
 		this.showBatchUploadSummary(successCount, failedCount, skippedCount);
 	}
 
+	/**
+	 * 基于内容的批量上传核心（不依赖编辑器），供自动监听等外部写入场景复用。
+	 * 传入笔记内容字符串，上传其中可上传的本地/远程图片，返回替换后的新内容与计数。
+	 * 复用与「批量替换当前笔记图片链接」命令完全相同的提取/过滤/上传/替换原语。
+	 */
+	async uploadImagesInText(
+		originalContent: string,
+		sourceFile: TFile | null,
+		sourcePath: string
+	): Promise<{ content: string; success: number; failed: number; skipped: number }> {
+		const allReferences = extractMarkdownAndWikiImageReferences(originalContent);
+		const settings = this.getSettings?.();
+		const excludedDomains = this.getExcludedDomains(settings);
+		const uploadableReferences = allReferences.filter((reference) => {
+			if (!reference.isRemote) {
+				return true;
+			}
+			return Boolean(settings?.enableNetworkImageUpload) && !this.isExcludedRemoteUrl(reference.path, excludedDomains);
+		});
+
+		if (uploadableReferences.length === 0) {
+			return { content: originalContent, success: 0, failed: 0, skipped: 0 };
+		}
+
+		const replacements: TextReplacement[] = [];
+		let successCount = 0;
+		let failedCount = 0;
+		const skippedCount = allReferences.length - uploadableReferences.length;
+
+		for (const reference of uploadableReferences) {
+			const uploadedUrl = reference.isRemote
+				? await this.uploadRemoteImage(reference.path, reference.altText, sourceFile)
+				: await this.uploadLocalImageReference(reference, sourcePath, sourceFile);
+
+			if (!uploadedUrl) {
+				failedCount++;
+				continue;
+			}
+
+			replacements.push({
+				index: reference.index,
+				length: reference.length,
+				replacement: this.buildReplacementForReference(reference, uploadedUrl)
+			});
+			successCount++;
+		}
+
+		return {
+			content: successCount > 0 ? this.applyReplacements(originalContent, replacements) : originalContent,
+			success: successCount,
+			failed: failedCount,
+			skipped: skippedCount
+		};
+	}
+
 	selectAndUploadImage(): void {
 		// 检查是否在移动端环境
 		const isMobile = Platform.isMobile;

--- a/src/utils/i18n.ts
+++ b/src/utils/i18n.ts
@@ -152,6 +152,20 @@ const translations: Record<Language, Translations> = {
 					name: '启用网络图片上传',
 					desc: '开启后，粘贴外链图片或执行“上传当前文档所有图片”命令时，会先抓取外链并上传到自己的图床；失败时保持原链接'
 				},
+				enableAutoUpload: {
+					name: '自动上传（外部写入时）',
+					desc: '监听文件改动：AI 经 CLI 写文件、Web Clip 存网页等从外部写入笔记时，自动把其中的本地/远程图片转存到图床并改写链接。需 Obsidian 处于运行状态；远程图片还需开启“启用网络图片上传”'
+				},
+				autoUploadFolders: {
+					name: '自动上传 · 监听文件夹',
+					desc: '逗号分隔的文件夹（如 clippings, inbox），留空表示监听整个库',
+					placeholder: '留空 = 整个库'
+				},
+				autoUploadDebounceMs: {
+					name: '自动上传 · 防抖（毫秒）',
+					desc: '文件停止改动多久后再处理，避免处理写到一半的内容。默认 2000，最小 500',
+					placeholder: '2000'
+				},
 				excludedImageDomains: {
 					name: '网络图片排除域名',
 					desc: '这些域名的图片链接不会重复上传，支持逗号或换行分隔。当前 API URL 域名会自动加入排除列表',
@@ -216,6 +230,7 @@ const translations: Record<Language, Translations> = {
 			noUploadableImages: '当前文档没有可上传的图片',
 			uploadingCurrentNoteImages: '正在上传当前文档中的 {count} 张图片...',
 			documentChangedSkipReplace: '文档内容已变化，本次未自动替换链接',
+			autoUploadSummary: 'CF ImageBed：已自动转存 {count} 张图片 → {file}',
 			checkFileSystemPermission: '请检查浏览器权限设置，允许访问文件系统',
 			uploadingImage: '正在上传图片...',
 			uploadSuccess: '图片上传成功：{url}',
@@ -403,6 +418,20 @@ const translations: Record<Language, Translations> = {
 					name: 'Enable remote image upload',
 					desc: 'When enabled, pasted remote image links and the “upload current note images” command will fetch remote images and upload them to your image bed. Failed uploads keep the original link.'
 				},
+				enableAutoUpload: {
+					name: 'Auto-upload on external write',
+					desc: 'Watch file changes: when notes are written from outside the editor (AI via CLI, web clipper, …), automatically upload their local/remote images and rewrite the links. Requires Obsidian to be running; remote images also need “Enable remote image upload”.'
+				},
+				autoUploadFolders: {
+					name: 'Auto-upload · watched folders',
+					desc: 'Comma-separated folders (e.g. clippings, inbox). Leave empty to watch the whole vault.',
+					placeholder: 'Empty = whole vault'
+				},
+				autoUploadDebounceMs: {
+					name: 'Auto-upload · debounce (ms)',
+					desc: 'How long to wait after the last change before processing, so half-written content is never touched. Default 2000, minimum 500.',
+					placeholder: '2000'
+				},
 				excludedImageDomains: {
 					name: 'Excluded remote domains',
 					desc: 'Images from these domains will not be uploaded again. Separate domains with commas or new lines. The current API URL domain is always excluded automatically.',
@@ -467,6 +496,7 @@ const translations: Record<Language, Translations> = {
 			noUploadableImages: 'No uploadable images found in the current note',
 			uploadingCurrentNoteImages: 'Uploading {count} images from the current note...',
 			documentChangedSkipReplace: 'The note content changed, so links were not replaced automatically',
+			autoUploadSummary: 'CF ImageBed: auto-uploaded {count} image(s) → {file}',
 			checkFileSystemPermission: 'Please check browser permissions and allow file system access',
 			uploadingImage: 'Uploading image...',
 			uploadSuccess: 'Image uploaded successfully: {url}',


### PR DESCRIPTION
## 动机

插件目前只在「用户在编辑器里粘贴 / 手动执行命令」时才会上传图片。但有一类很常见的写入方式完全绕开了编辑器：

- AI 工具经 CLI 直接往库里写 Markdown 文件
- 网页剪藏器 / 脚本把网页存成笔记

这些笔记落盘后，里面的本地图片和外链图片插件是感知不到的，必须事后手动对每篇执行一次「上传当前文档所有图片」。

本 PR 增加一个**可选、默认关闭**的监听器，让这类外部写入也能自动转存到图床。

## 实现

新增 `src/events/autoUploadWatcher.ts`，监听 vault 的 `create` / `modify`，对 `.md` 文件自动执行上传 + 链接改写。

自动改写用户文件风险很高，所以做了四道保险：

| 风险 | 处理 |
|---|---|
| Obsidian 启动时全库触发 `create` 事件风暴 | 只在 `workspace.onLayoutReady` 之后才注册监听 |
| 文件还在写入途中就被处理 | 每个文件独立防抖（默认 2000ms，下限 500ms） |
| 自己改写又触发 `modify` → 死循环 | `processing` 集合断环 + 幂等性（转存后图片已落在被排除的图床域，二次扫描命中 0） |
| 覆盖掉处理期间用户的新编辑 | `vault.process` 原子写回，且**仅当磁盘内容仍等于处理时的快照**才覆盖 |

同时把命令式逻辑抽出一个基于文本的核心 `ImageHandler.uploadImagesInText()`，供命令和监听器共用，避免重复实现。

## 新增设置（高级设置页，全部走 i18n）

- `enableAutoUpload` — 总开关，**默认关闭**
- `autoUploadFolders` — 逗号分隔的监听文件夹，留空 = 整个库
- `autoUploadDebounceMs` — 防抖毫秒，默认 2000

远程图片仍需同时开启已有的「启用网络图片上传」。

## 已知限制

- **只在 Obsidian 运行期间生效，没有启动时补扫**：Obsidian 关闭期间被外部写入的笔记不会被处理，需要手动跑一次命令。如果维护者认为有必要，我可以补一个可选的启动补扫。
- 目前是在自用环境下运行验证，尚未做覆盖各种边界的系统测试。

## 影响面

+215 行，全部为新增；未修改任何既有代码路径。开关默认关闭，不开启时行为与现在完全一致。已在 1.0.9 上通过 `tsc --noEmit`。
